### PR TITLE
Fix the custom merge sort, which could lead to crash on very simple data

### DIFF
--- a/MPE_fastpoly2tri.h
+++ b/MPE_fastpoly2tri.h
@@ -1879,7 +1879,7 @@ void MPE_PolySort(MPEPolyPoint** Points, MPEPolyPoint** Temp, u32 Count)
     MPEPolyPoint** ReadHalf1 = InHalf1;
 
     //NOTE: Don't merge if two halves are already sorted
-    if (InHalf1[-1]->Y > InHalf1[0]->Y)
+    if (InHalf1[-1]->Y >= InHalf1[0]->Y)
     {
       MPEPolyPoint** Out = Temp;
       for (u32 WriteIndex = 0; WriteIndex < Count; ++WriteIndex)


### PR DESCRIPTION
Thanks for the library!

I encountered crash when testing it with very simple data. Fortunately, it it not hard to find the bug. In the custom merge sort function, it may requires sorting when `InHalf1[-1]->Y == InHalf1[0]->Y`.

Also note that, the way epsilon is used in the sorting section is incorrect. For the following points, both `MPE_POLY_COMPARE(A, B)` and `MPE_POLY_COMPARE(B, A)` are `true`.
```
A = 2, 1
B = 1, 1+eps/2
```
I can make another pull request for this.